### PR TITLE
Fix multiple disable/enable scroll on iOS device

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -165,13 +165,17 @@ export const clearAllBodyScrollLocks = (): void => {
 
 export const enableBodyScroll = (targetElement: any): void => {
   if (isIosDevice) {
-    if (targetElement === firstTargetElement) {
-      document.body.removeEventListener('touchstart', handlers.get(targetElement));
-      document.body.removeEventListener('touchmove', handlers.get(targetElement));
-      handlers.delete(targetElement);
-
-      firstTargetElement = null;
-    }
+    allTargetElements.forEach(function(target) {
+      if (targetElement === target) {
+        document.body.removeEventListener('touchstart', handlers.get(targetElement));
+        document.body.removeEventListener('touchmove', handlers.get(targetElement));
+        handlers.delete(targetElement);
+  
+        if (targetElement === firstTargetElement) {
+          firstTargetElement = null;
+        }
+      }
+    });
 
     targetElement.ontouchstart = null;
     targetElement.ontouchmove = null;


### PR DESCRIPTION
When multiple disable/enable scroll on iOS device, after enable scroll is not working.

When I do enableBodyScroll, because the second registered event is not firstTargetElement, the event is not detached and the touch event does not occur.

So I added searching allTargetElement for detach touch events.